### PR TITLE
fix: Enabling CORS in a Next.js App

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -8,5 +8,19 @@ module.exports = {
   },
   publicRuntimeConfig: {
     branchName: process.env.VERCEL_GIT_COMMIT_REF
+  },
+  async headers () {
+    return [
+      {
+        // matching all API routes
+        source: '/api/:path*',
+        headers: [
+          { key: 'Access-Control-Allow-Credentials', value: 'true' },
+          { key: 'Access-Control-Allow-Origin', value: '*' },
+          { key: 'Access-Control-Allow-Methods', value: 'GET,OPTIONS,PATCH,DELETE,POST,PUT' },
+          { key: 'Access-Control-Allow-Headers', value: 'X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version' }
+        ]
+      }
+    ]
   }
 }


### PR DESCRIPTION
@alexsimkovich @lukasz-galka 
Na main https://patronage22-szczecin-js.vercel.app/ nie da się dodać tablicy. W network dostajemy błąd "Access to XMLHttpRequest at 'https://patronage22-szczecin-js-ny34oxjk2-patronage22szczecinjs.vercel.app/api/boards/' from origin 'https://patronage22-szczecin-js.vercel.app' has been blocked by CORS policy: Response to preflight request doesn't pass access control check: Redirect is not allowed for a preflight request."
Dodałem enable CORS do `pliku next.config.js`.
Source: https://vercel.com/support/articles/how-to-enable-cors