### PR TITLE
fix: P2022-1984 Board name is displaying outside tile in case of …

### DIFF
--- a/components/BoardTile/__snapshots__/BoardTile.test.js.snap
+++ b/components/BoardTile/__snapshots__/BoardTile.test.js.snap
@@ -17,7 +17,7 @@ exports[`BoardTile renders correctly with password 1`] = `
       </span>
     </div>
     <h4
-      class="sc-dkPtRN kUDuei"
+      class="sc-dkPtRN gwlfTF"
     >
       Board name 1
     </h4>
@@ -103,7 +103,7 @@ exports[`BoardTile renders correctly without password 1`] = `
     href="/boards/mockId"
   >
     <h4
-      class="sc-dkPtRN kUDuei"
+      class="sc-dkPtRN gwlfTF"
     >
       Board name 1
     </h4>

--- a/components/BoardTile/style.js
+++ b/components/BoardTile/style.js
@@ -32,6 +32,7 @@ export const Header = styled.h4`
   font-weight: 400;
   line-height: 1.5rem;
   color: #515151;
+  word-break: break-word;
 `
 export const TileFooter = styled.div`
   display: flex;

--- a/pages/__snapshots__/index.test.js.snap
+++ b/pages/__snapshots__/index.test.js.snap
@@ -56,7 +56,7 @@ exports[`Home should render Home page 1`] = `
         href="/boards/1"
       >
         <h4
-          class="sc-dkPtRN kUDuei"
+          class="sc-dkPtRN gwlfTF"
         >
           mockedName
         </h4>


### PR DESCRIPTION
Current version for testing: https://patronage22-szczecin-a39g6s61b-patronage22szczecinjs.vercel.app/
Ticket: https://tracker.intive.com/jira/browse/P2022-1984