### PR TITLE
fix: P2022-1986 Padlock icon overlapping long board name

### DIFF
--- a/components/BoardTile/__snapshots__/BoardTile.test.js.snap
+++ b/components/BoardTile/__snapshots__/BoardTile.test.js.snap
@@ -17,7 +17,7 @@ exports[`BoardTile renders correctly with password 1`] = `
       </span>
     </div>
     <h4
-      class="sc-dkPtRN gwlfTF"
+      class="sc-dkPtRN jbOLNK"
     >
       Board name 1
     </h4>
@@ -103,7 +103,7 @@ exports[`BoardTile renders correctly without password 1`] = `
     href="/boards/mockId"
   >
     <h4
-      class="sc-dkPtRN gwlfTF"
+      class="sc-dkPtRN jbOLNK"
     >
       Board name 1
     </h4>

--- a/components/BoardTile/style.js
+++ b/components/BoardTile/style.js
@@ -27,6 +27,7 @@ export const IconWrapper = styled.div`
 `
 
 export const Header = styled.h4`
+  z-index: 1;
   margin-bottom: 0.25rem;
   font-size: 1rem;
   font-weight: 400;

--- a/pages/__snapshots__/index.test.js.snap
+++ b/pages/__snapshots__/index.test.js.snap
@@ -56,7 +56,7 @@ exports[`Home should render Home page 1`] = `
         href="/boards/1"
       >
         <h4
-          class="sc-dkPtRN gwlfTF"
+          class="sc-dkPtRN jbOLNK"
         >
           mockedName
         </h4>


### PR DESCRIPTION
Current version for testing: https://patronage22-szczecin-js-ic1iq5hgg-patronage22szczecinjs.vercel.app/
Ticket: https://tracker.intive.com/jira/browse/P2022-1986